### PR TITLE
Fix monitor detection when primary is set

### DIFF
--- a/polywins.sh
+++ b/polywins.sh
@@ -24,6 +24,7 @@ wm_border_width=0 # setting this might be required for accurate resize position
 # Multi-monitor setup
 read monitor_width monitor_height monitor_x monitor_y <<EOF
 	$(xrandr --query |
+	sed -e 's/ primary//' |
 	awk -v m=$MONITOR -F'[ x+]' '{if ($1 ~ m) {print $3" "$4" "$5" "$6}}')
 EOF
 monitor_x_right=$(($monitor_x+$monitor_width))


### PR DESCRIPTION
When a monitor is set as primary, the "xrandr --query | awk ..." command will not work, as the primary tag will be prepended to the width and height of the monitor and those will now be offset. A simple sed strips the " primary" string when present and fixes it.